### PR TITLE
Fix exit after first song

### DIFF
--- a/plugin.audio.pandoki/resources/lib/pandoki/pandoki.py
+++ b/plugin.audio.pandoki/resources/lib/pandoki/pandoki.py
@@ -899,7 +899,7 @@ class Pandoki(object):
             self.List()
             self.Scan()
             
-            for i in range(10):
+            for i in range(20):
                 if not (self.once or self.player.isPlayingAudio()):
                     xbmc.sleep(100)
                 else:

--- a/plugin.audio.pandoki/resources/lib/pandoki/pandoki.py
+++ b/plugin.audio.pandoki/resources/lib/pandoki/pandoki.py
@@ -898,6 +898,13 @@ class Pandoki(object):
             self.Deque()
             self.List()
             self.Scan()
+            
+            for i in range(10):
+                if not (self.once or self.player.isPlayingAudio()):
+                    xbmc.sleep(100)
+                else:
+                    break
+                
         if (self.player.isPlayingAudio()):
             notification('Exiting', '[COLOR lime]No longer queuing new songs[/COLOR]' , '5000', iconart)
         Log('Pankodi Exiting XBMCAbort?=%s PandokiAbort?=%s ' % (xbmc.abortRequested, self.abort), None, level = xbmc.LOGNOTICE)


### PR DESCRIPTION
This is what I did to fix the exiting after the first song when using kodi 18. For some reason when it checks to see if kodi is playing audio sometime kodi says that it is not. If it is checked again it says it is playing and loads the rest of the songs ok. 