### PR TITLE
Add mediatype to playlist songs

### DIFF
--- a/plugin.audio.pandoki/resources/lib/pandoki/pandoki.py
+++ b/plugin.audio.pandoki/resources/lib/pandoki/pandoki.py
@@ -235,7 +235,7 @@ class Pandoki(object):
 
     def Info(self, s):
         log('def Info')
-        info = { 'artist' : s['artist'], 'album' : s['album'], 'title' : s['title'], 'rating' : s['rating'] }
+        info = { 'artist' : s['artist'], 'album' : s['album'], 'title' : s['title'], 'rating' : s['rating'], 'mediatype':'song' }
 
         if s.get('duration'):
             info['duration'] = s['duration']


### PR DESCRIPTION
add 'mediatype':'song' to playlist listitems
this allows Kodi to open the songinformation dialog for the songs in the playlist.  Skins can use this to provide additional info for the songs (for example, retrieve artist info from artwork slideshow addon).